### PR TITLE
fix(flake): update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -535,11 +535,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1728249353,
-        "narHash": "sha256-7NBJm1jfMeAowE1J2oljYqWVvI9X7FyyxBY4O8uB/Os=",
+        "lastModified": 1730272153,
+        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8a17040be4a20b29589cb4043a9e0c36af1930e",
+        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Overview
Updates nixpkgs to latest.

## Background
I was encountering the follow error when previewing (`.tsx`) files in telescope's preview window:
```bash
Error executing vim.schedule lua callback: ...rapped-nightly/share/nvim/runtime/lua/vim/treesitter.lua:425: Parser could not be created for buffer 12 and language "typescriptreact"                
stack traceback:                                                                                                                                                                                    
        [C]: in function 'assert'                                                                                                                                                                   
        ...rapped-nightly/share/nvim/runtime/lua/vim/treesitter.lua:425: in function 'ts_highlighter'                                                                                               
        .../start/telescope.nvim/lua/telescope/previewers/utils.lua:154: in function 'highlighter'                                                                                                  
        ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:233: in function ''                                                                                                             
        vim/_editor.lua: in function <vim/_editor.lua:0> 
```

Bug in upstream `nvim-treesitter` library was fixed [here](https://github.com/nvim-treesitter/nvim-treesitter/commit/707e352df6d737e545e1a7204f7395ba82e6d2d3). I created this PR to document how my knowledge of nix was exercised and how I gained a better understanding of nix.

This exercised the following:
- If there is a bug upstream, and the fix hasn't made it to nix's downstream package, what is my escape hatch to pull in the upstream fix
- How many commits behind is downstream from upstream
- How should I better manage unstable branches of certain dependencies

This also got me thinking a bit more about NixOS's approach to reproducibility, and that it can introduce complexities when dealing with software that expects mutable filesystems. Case in point being `nvim-treesitter`. Thankfully this is documented [here](https://github.com/NixOS/nixpkgs/blob/f17450bb06fa97d390aae3ed62e7fa7b1612a813/doc/languages-frameworks/vim.section.md#specificities-for-some-plugins-vim-plugin-specificities).

